### PR TITLE
Reduce the verbosity level of the FileNotFound exception.

### DIFF
--- a/dj_field_filemanager/models.py
+++ b/dj_field_filemanager/models.py
@@ -181,6 +181,8 @@ class DocumentModel(models.Model, ThumbnailMixin):
 
         try:
             rmdir(folder)
+        except FileNotFoundError as e:
+            logger.debug(e)
         except Exception as e:
             logger.warning(e)
 


### PR DESCRIPTION
We initially planned on solving this by checking if the file exists, but in my opinion this is a better approach.